### PR TITLE
Add viewable versions of the documentation links

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ Install with [bower](http://bower.io).
 ```bash 
 bower install markerclustererplus --save
 ```
-
+  		  
 ### Additional Features
 
 * hideLabel option - removes numbers on the clusters
@@ -40,6 +40,10 @@ To rebuild a minified version of the library try the following commands:
 $ npm install
 $ npm run build
 ```
+### Documentation
+
+* [Reference](http://htmlpreview.github.io/?https://github.com/mahnunchik/markerclustererplus/blob/master/docs/reference.html)
+* [Examples](http://htmlpreview.github.io/?https://github.com/mahnunchik/markerclustererplus/blob/master/docs/examples.html)
 
 ### License
 


### PR DESCRIPTION
Currently the files in the docs directory can not be easily viewed or found online. I was eventually able to track down this link after a lot of searching http://google-maps-utility-library-v3.googlecode.com/svn/tags/markerclustererplus/2.0.15/docs/reference.html, however there is no way I know of to make this dynamically update to always point to the latest version. For this reason I'm using github.io's html-preview feature to render the html docs in this repository.
