### PR TITLE
Added alt attribute to the ClusterIcon Image

### DIFF
--- a/src/markerclusterer.js
+++ b/src/markerclusterer.js
@@ -248,7 +248,7 @@ ClusterIcon.prototype.show = function () {
     var spriteV = parseInt(bp[1].trim(), 10);
     var pos = this.getPosFromLatLng_(this.center_);
     this.div_.style.cssText = this.createCss(pos);
-    img = "<img src='" + this.url_ + "' style='position: absolute; top: " + spriteV + "px; left: " + spriteH + "px; ";
+    img = "<img alt='' src='" + this.url_ + "' style='position: absolute; top: " + spriteV + "px; left: " + spriteH + "px; ";
     if (!this.cluster_.getMarkerClusterer().enableRetinaIcons_) {
       img += "clip: rect(" + (-1 * spriteV) + "px, " + ((-1 * spriteH) + this.width_) + "px, " +
           ((-1 * spriteV) + this.height_) + "px, " + (-1 * spriteH) + "px);";


### PR DESCRIPTION
To improve Accessibility Ensure all informative <img> elements have short, descriptive alternate text and all decorative <img> elements have empty alt attributes.